### PR TITLE
Add Python3.5 (and pypy3.5) support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 dist: xenial
-
-language: python
-
 sudo: false
 
+language: python
 python:
+  - "3.5"
   - "3.6"
   - "3.7"
   - "3.7-dev"
   - "3.8-dev"
   - "nightly"
+  - "pypy3.5"
 
 install:
   - pip install --upgrade pip

--- a/exact_cover.py
+++ b/exact_cover.py
@@ -21,7 +21,7 @@ def exact_cover_gurobi(bitstrings, cover_string_length):
     used = set()
     anything = False
     try:
-        tdir = tempfile.mkdtemp(prefix='combcov_tmp')
+        tdir = str(tempfile.mkdtemp(prefix='combcov_tmp'))
         inp = os.path.join(tdir, 'inp.lp')
         outp = os.path.join(tdir, 'out.sol')
 

--- a/tests/test_exact_cover.py
+++ b/tests/test_exact_cover.py
@@ -8,7 +8,7 @@ import exact_cover
 
 
 def _mocked_call_Popen(inp, outp):
-    dir = Path(__file__).parents[0]
+    dir = str(Path(__file__).parents[0])
     av_21_inp_lp = os.path.join(dir, 'av_21', 'inp.lp')
     av_21_out_sol = os.path.join(dir, 'av_21', 'out.sol')
 


### PR DESCRIPTION
- str() casting variables that are used with os.path.join() so it works with Python 3.5 and pypy3.5