### PR TITLE
MeshTiling demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,25 +15,22 @@ extended for other types of combinatorial objects.
 
 ## Demo
 
-Take a look at `demo/string_set.py` as an example on how to use `CombCov` with
-your own combinatorial object. It finds a _String Set_ cover for the set of
-string over the alphabet `{a,b}` that avoids the substring `aa` (meaning no
-string in the set contains `aa` as a substring).
+Take a look at the `demo/` folder in this repo to see examples on how to use
+`CombCov` with your own combinatorial object. On example finds a _String Set_
+cover for the set of string over the alphabet `{a,b}` that avoids the substring
+`aa` (meaning no string in the set contains `aa` as a substring).
 
 ```bash
-python -m demo.string_set
-```
-
-It prints out the following:
-
-```text
-Trying to find a cover for ''*Av(aa) over ∑={a,b} using elements up to size 7.
-(Enumeration: [1, 2, 3, 5, 8, 13, 21, 34])
+>>> python -m demo.string_set
+[INFO] bitstring to cover: 154742504910672534362390527 
+[INFO] Total of 16 subrules
+[INFO] Trying to find a cover for ''*Av(aa) over ∑={a,b} using elements up to size 7.
+Enumeration: [1, 2, 3, 5, 8, 13, 21, 34]
 Solution nr. 1:
- - ''*Av(a,b) over ∑={a,b}
- - 'a'*Av(a,b) over ∑={a,b}
- - 'b'*Av(aa) over ∑={a,b}
- - 'ab'*Av(aa) over ∑={a,b}
+ - Rule #1: ''*Av(b,a) over ∑={a,b} with bitstring 1
+ - Rule #2: 'a'*Av(b,a) over ∑={a,b} with bitstring 2
+ - Rule #3: 'b'*Av(aa) over ∑={a,b} with bitstring 154742431132702343545997108
+ - Rule #4: 'ab'*Av(aa) over ∑={a,b} with bitstring 73777970190816393416
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A generalization of the permutation-specific algorithm [Struct](https://github.c
 extended for other types of combinatorial objects.
 
 
-## Demo
+## Demos
 
 Take a look at the `demo/` folder in this repo to see examples on how to use
 `CombCov` with your own combinatorial object. On example finds a _String Set_
@@ -21,11 +21,12 @@ cover for the set of string over the alphabet `{a,b}` that avoids the substring
 `aa` (meaning no string in the set contains `aa` as a substring).
 
 ```bash
->>> python -m demo.string_set
+$ python -m demo.string_set
+[INFO] Total of 87 elements of size up to 7
+[INFO] Enumeration: [1, 2, 3, 5, 8, 13, 21, 34]
 [INFO] bitstring to cover: 154742504910672534362390527 
 [INFO] Total of 16 subrules
 [INFO] Trying to find a cover for ''*Av(aa) over ∑={a,b} using elements up to size 7.
-Enumeration: [1, 2, 3, 5, 8, 13, 21, 34]
 Solution nr. 1:
  - Rule #1: ''*Av(b,a) over ∑={a,b} with bitstring 1
  - Rule #2: 'a'*Av(b,a) over ∑={a,b} with bitstring 2

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ cover for the set of string over the alphabet `{a,b}` that avoids the substring
 $ python -m demo.string_set
 [INFO] Total of 87 elements of size up to 7
 [INFO] Enumeration: [1, 2, 3, 5, 8, 13, 21, 34]
-[INFO] bitstring to cover: 154742504910672534362390527 
+[INFO] Bitstring to cover: 154742504910672534362390527 
 [INFO] Total of 16 subrules
 [INFO] Trying to find a cover for ''*Av(aa) over ∑={a,b} using elements up to size 7.
 Solution nr. 1:

--- a/combcov/combcov.py
+++ b/combcov/combcov.py
@@ -29,7 +29,7 @@ class CombCov():
 
     def _create_binary_strings_from_rules(self):
         string_to_cover = 2 ** len(self.elmnts_dict) - 1
-        print("[INFO] bitstring to cover: {} ".format(string_to_cover))
+        print("[INFO] Bitstring to cover: {} ".format(string_to_cover))
 
         self.rules = []
         self.bitstrings = []

--- a/combcov/combcov.py
+++ b/combcov/combcov.py
@@ -19,6 +19,10 @@ class CombCov():
             self.enumeration[n] = len(elmnts_of_length_n)
             elmnts.extend(elmnts_of_length_n)
 
+        print("[INFO] Total of {} elements of size up to {}".format(
+            len(elmnts), self.max_elmnt_size))
+        print("[INFO] Enumeration: {}".format(self.enumeration))
+
         self.elmnts_dict = {
             string: nr for nr, string in enumerate(elmnts, start=0)
         }

--- a/combcov/combcov.py
+++ b/combcov/combcov.py
@@ -24,12 +24,25 @@ class CombCov():
         }
 
     def _create_binary_strings_from_rules(self):
-        self.rules_dict = {}
+        string_to_cover = 2 ** len(self.elmnts_dict) - 1
+        print("[INFO] bitstring to cover: {} ".format(string_to_cover))
+
         self.rules = []
+        self.bitstrings = []
+        self.bitstring_to_rules_dict = {}
+        self.rules_to_bitstring_dict = {}
+
         for rule in self.root_object.get_subrules():
-            rule_is_good = True
-            binary_string = 0
+            if rule in self.rules:
+                rule_is_good = False
+            else:
+                rule_is_good = True
+                binary_string = 0
+
             for elmnt_size in range(self.max_elmnt_size + 1):
+                if not rule_is_good:
+                    break
+
                 seen_elmnts = set()
                 for elmnt in rule.get_elmnts(of_size=elmnt_size):
                     if elmnt not in self.elmnts_dict or elmnt in seen_elmnts:
@@ -39,23 +52,33 @@ class CombCov():
                         seen_elmnts.add(elmnt)
                         binary_string += 2 ** (self.elmnts_dict[elmnt])
 
-                if not rule_is_good:
-                    break
+                # Throwing out single-rule covers
+                if binary_string == string_to_cover:
+                    rule_is_good = False
 
             if rule_is_good:
                 self.rules.append(rule)
-                self.rules_dict[rule] = binary_string
+                self.rules_to_bitstring_dict[rule] = binary_string
+
+                # ToDo: Use defaultdict for more readable syntax
+                if binary_string not in self.bitstring_to_rules_dict:
+                    self.bitstrings.append(binary_string)
+                    self.bitstring_to_rules_dict[binary_string] = [rule]
+                else:
+                    self.bitstring_to_rules_dict[binary_string].append(rule)
 
     def solve(self):
-        self.ec = ExactCover(list(self.rules_dict.values()),
-                             len(self.elmnts_dict))
+        print("[INFO] Trying to find a cover for {} using elements up to size "
+              "{}.".format(self.root_object, self.max_elmnt_size))
+        self.ec = ExactCover(self.bitstrings, len(self.elmnts_dict))
         self.solutions_indices = self.ec.exact_cover()
 
     def get_solutions(self):
         solutions = []
         for solution_indices in self.solutions_indices:
-            solution = [self.rules[binary_string] for binary_string in
-                        solution_indices]
+            solution = [
+                self.bitstring_to_rules_dict[self.bitstrings[bitstring_index]][
+                    0] for bitstring_index in solution_indices]
             solutions.append(solution)
 
         return solutions

--- a/demo/__init__.py
+++ b/demo/__init__.py
@@ -1,1 +1,2 @@
+from .mesh_tiling import MeshTiling
 from .string_set import StringSet

--- a/demo/mesh_tiling.py
+++ b/demo/mesh_tiling.py
@@ -122,13 +122,10 @@ class MeshTiling(Rule):
         elif cell == self.point_cell:
             return PermSet(1)
         elif cell == self.avoiding_nothing_cell:
-            return Av([])
+            return PermSet()
         else:
             obstructions = cell[self.obs_index]
             return MockAvMeshPatt(obstructions)
-
-    def __len__(self):
-        return self.columns * self.rows
 
     def get_elmnts(self, of_size):
         # Return permutations of length 'of_size' on a MeshTiling like this:
@@ -296,9 +293,15 @@ class MeshTiling(Rule):
         print("[INFO] Total of {} subrules".format(len(subrules)))
         return subrules
 
+    def get_dimension(self):
+        return (self.columns, self.rows)
+
     def _key(self):
         return (frozenset(self.requirements.items()),
                 frozenset(self.obstructions.items()))
+
+    def __len__(self):
+        return self.columns * self.rows
 
     def __str__(self):
         return "({}x{}) {}".format(self.columns, self.rows, self.grid)

--- a/demo/mesh_tiling.py
+++ b/demo/mesh_tiling.py
@@ -73,14 +73,13 @@ class Cell(namedtuple('Cell', ['obstructions', 'requirements'])):
 
 class MeshTiling(Rule):
 
-    def __init__(self, obstructions, requirements):
-        # Constants (ToDo: make into 'cls' variables?)
-        self.uninitialized_cell = Cell(None, None)
-        self.empty_cell = Cell(frozenset({Perm((0,))}), frozenset())
-        self.point_cell = Cell(frozenset({Perm((0, 1)), Perm((1, 0))}),
-                               frozenset({Perm((0,))}))
-        self.anything_cell = Cell(frozenset(), frozenset())
+    uninitialized_cell = Cell(None, None)
+    empty_cell = Cell(frozenset({Perm((0,))}), frozenset())
+    point_cell = Cell(frozenset({Perm((0, 1)), Perm((1, 0))}),
+                      frozenset({Perm((0,))}))
+    anything_cell = Cell(frozenset(), frozenset())
 
+    def __init__(self, obstructions, requirements):
         self.MAX_COLUMN_DIMENSION = 3
         self.MAX_ROW_DIMENSION = 3
         self.MAX_ACTIVE_CELLS = 3

--- a/demo/mesh_tiling.py
+++ b/demo/mesh_tiling.py
@@ -1,0 +1,295 @@
+import itertools
+from operator import itemgetter
+
+from combcov import CombCov, Rule
+from permuta import Av, MeshPatt, Perm, PermSet
+from permuta.misc import flatten, ordered_set_partitions
+
+
+class MockAvMeshPatt():
+    def __init__(self, mesh_patterns):
+        self.mesh_patterns = mesh_patterns
+        if isinstance(mesh_patterns, MeshPatt):
+            self.filter_function = lambda perm: perm.avoids(mesh_patterns)
+        elif all(isinstance(mp, MeshPatt) for mp in mesh_patterns):
+            self.filter_function = lambda perm: all(
+                perm.avoids(mp) for mp in mesh_patterns)
+        elif all(isinstance(p, Perm) for p in mesh_patterns):
+            print("[WARNING] mesh_patterns are all instances of "
+                  "'Perm': {}".format(mesh_patterns))
+            self.filter_function = lambda perm: perm in Av(mesh_patterns)
+        else:
+            raise ValueError("'mesh_patterns' variable not as expected: "
+                             "'{}'".format(mesh_patterns))
+
+    def of_length(self, size):
+        perm_set = PermSet(size)
+        return filter(self.filter_function, perm_set)
+
+
+class MeshTiling(Rule):
+
+    # ToDo: switch argument order (as it's done in Tilings)
+    def __init__(self, requirements, obstructions):
+        # Constants (ToDo: make into 'cls' variables?)
+        self.point = Perm((0,))
+        self.point_obstruction = [Perm((0, 1)), Perm((1, 0))]
+        self.unintialized_cell = [[], []]
+        self.empty_cell = [[self.point], []]
+        self.point_cell = [[Perm((0, 1)), Perm((1, 0))], [self.point]]
+
+        self.x_dim = 0
+        self.y_dim = 1
+        self.obs_index = 0
+        self.reqs_index = 1
+
+        def _calc_dim(reqs, obs, dimension):
+            return max(
+                list(reqs) + list(obs) + [(0, 0)],
+                key=itemgetter(dimension)
+            )[dimension]
+
+        self.columns = _calc_dim(requirements, obstructions, self.x_dim) + 1
+        self.rows = _calc_dim(requirements, obstructions, self.y_dim) + 1
+
+        self.requirements = requirements
+        self.obstructions = obstructions
+        self.grid = [[[[] for _ in range(2)] for _ in range(self.rows)] for _
+                     in range(self.columns)]
+
+        # Populate requirements...
+        for (c, r), req_list in requirements.items():
+            self.grid[c][r][self.reqs_index] = req_list
+
+        # ...and obstructions...
+        for (c, r), obs_list in obstructions.items():
+            self.grid[c][r][self.obs_index] = obs_list
+
+        # ...and then the rest are empty cells
+        for (c, r) in itertools.product(range(self.columns), range(self.rows)):
+            if self.grid[c][r] == self.unintialized_cell:
+                self.grid[c][r] = self.empty_cell
+
+    # Linear number = (column, row)
+    #   -----------------------------------
+    #  | 3 = (0,1) | 4 = (1,1) | 5 = (2,1) |
+    #  |-----------+-----------+-----------|
+    #  | 0 = (0,0) | 1 = (1,0) | 2 = (2,0) |
+    #   -----------------------------------
+    def convert_linear_number_to_coordinates(self, number):
+        if number < 0 or number >= self.columns * self.rows:
+            raise IndexError
+        else:
+            col = number % self.columns
+            row = number // self.columns
+            return (col, row)
+
+    def convert_coordinates_to_linear_number(self, col, row):
+        if col < 0 or col >= self.columns or row < 0 or row >= self.rows:
+            raise IndexError
+        else:
+            return row * self.columns + col
+
+    def is_point(self, cell):
+        return cell[self.reqs_index] == [self.point] and cell[
+            self.obs_index] == self.point_obstruction
+
+    def make_tiling(self):
+        # Flattening the 2D self.grid into a 1D list
+        tiling = []
+        for row in range(self.rows):
+            row_content = [self.grid[i][row] for i in range(self.columns)]
+            tiling.extend(row_content)
+        return tiling
+
+    def permclass_from_cell(self, cell):
+        if cell == self.empty_cell:
+            return Av(Perm((0,)))
+        elif cell == self.point_cell:
+            return PermSet(1)
+        else:
+            obstructions = cell[self.obs_index]
+            return MockAvMeshPatt(obstructions)
+
+    def __len__(self):
+        return self.columns * self.rows
+
+    def get_elmnts(self, of_size):
+        # Return permutations of length 'of_size' on a MeshTiling like this:
+        #
+        #      ------------------------
+        #     |          | o |         |
+        #     |----------+---+---------|
+        #     | Av(31#2) |   | Av(1#2) |
+        #      ------------------------
+        #
+        # The following code was shamelessly ported and adapted from
+        # PermutaTriangle/grids repo, grids/Tilings.py file
+
+        w = self.columns
+        h = self.rows
+
+        tiling = self.make_tiling()
+
+        def permute(arr, perm):
+            res = [None] * len(arr)
+            for i in range(len(arr)):
+                res[i] = arr[perm[i]]
+            return res
+
+        def count_assignments(at, left):
+            if at == len(self):
+                # base case in recursion
+                if left == 0:
+                    yield []
+            else:
+                if self.is_point(tiling[at]):
+                    # one point in cell
+                    if left > 0:
+                        for ass in count_assignments(at + 1, left - 1):
+                            yield [1] + ass
+                elif tiling[at] == self.empty_cell:
+                    # no point in cell
+                    for ass in count_assignments(at + 1, left):
+                        yield [0] + ass
+                else:
+                    for cur in range(left + 1):
+                        for ass in count_assignments(at + 1, left - cur):
+                            yield [cur] + ass
+
+        elmnts_list = []
+        for count_ass in count_assignments(0, of_size):
+            cntz = [[0 for j in range(w)] for i in range(h)]
+
+            for i, k in enumerate(count_ass):
+                (col, row) = self.convert_linear_number_to_coordinates(i)
+                cntz[row][col] = k
+
+            rowcnt = [sum(cntz[ro][co] for co in range(w)) for ro in range(h)]
+            colcnt = [sum(cntz[ro][co] for ro in range(h)) for co in range(w)]
+
+            for colpart in itertools.product(*[
+                    ordered_set_partitions(
+                        range(colcnt[col]), [
+                            cntz[row][col] for row in range(h)
+                        ]
+                    ) for col in range(w)]):
+                scolpart = [[sorted(colpart[i][j]) for j in range(h)] for i in
+                            range(w)]
+                for rowpart in itertools.product(*[
+                    ordered_set_partitions(range(rowcnt[row]),
+                                           [cntz[row][col] for col in
+                                            range(w)]) for row in range(h)]):
+                    srowpart = [[sorted(rowpart[i][j]) for j in range(w)] for i
+                                in range(h)]
+                    for perm_ass in itertools.product(
+                            *[self.permclass_from_cell(s).of_length(cnt) for
+                              cnt, s in zip(count_ass, tiling)]):
+                        arr = [[[] for j in range(w)] for i in range(h)]
+
+                        for i, perm in enumerate(perm_ass):
+                            (col,
+                             row) = self.convert_linear_number_to_coordinates(
+                                i)
+                            arr[row][col] = perm
+
+                        res = [[None] * colcnt[col] for col in range(w)]
+
+                        cumul = 0
+                        for row in range(h):
+                            for col in range(w):
+                                for idx, val in zip(scolpart[col][row],
+                                                    permute(srowpart[row][col],
+                                                            arr[row][col])):
+                                    res[col][idx] = cumul + val
+                            cumul += rowcnt[row]
+                        elmnts_list.append(Perm(flatten(res)))
+
+        return elmnts_list
+
+    def get_subrules(self):
+        # Subrules are MeshTilings of sizes ranging from 1 x 1 to c x r
+        # where c is the number of columns of the root object + 2 and
+        # r is the number of rows in the root ojbect + 1. Each cell contains
+        # a mix of requirements (Perms) and obstructions (MeshPatts) where
+        # the obstructions are sub mesh patterns of any of the obstructions
+        # in the root object.
+
+        cell_choices = {self.point}
+        for obstruction_list in self.obstructions.values():
+            for obstruction in obstruction_list:
+                if isinstance(obstruction, MeshPatt):
+                    n = len(obstruction)
+                    for i in range(n):
+                        cell_choices.update(set(
+                            obstruction.sub_mesh_pattern(indices) for indices
+                            in itertools.combinations(range(n), i + 1)
+                        ))
+                elif isinstance(obstruction, Perm):
+                    # Is there a method for sub-perms?
+                    cell_choices.add(obstruction)
+                else:
+                    raise ValueError(
+                        "[ERROR] obstruction '{}' neither MeshPatt "
+                        "or Perm!".format(obstruction))
+
+        subrules = []
+        for (dim_col, dim_row) in itertools.product(range(1, self.columns + 3),
+                                                    range(1, self.rows + 2)):
+
+            nr_of_cells = dim_col * dim_row
+
+            for how_many_active_cells in range(4):
+                for active_cells in itertools.product(
+                        cell_choices, repeat=how_many_active_cells):
+                    for combination in itertools.combinations(
+                            range(nr_of_cells), how_many_active_cells):
+                        requirements = {}
+                        obstructions = {}
+                        for i, cell_index in enumerate(combination):
+                            cell = active_cells[i]
+                            col = cell_index % dim_col
+                            row = cell_index // dim_col
+                            if cell == self.point:
+                                requirements[(col, row)] = [self.point]
+                                obstructions[
+                                    (col, row)] = self.point_obstruction
+                            else:
+                                # List of MeshPatts
+                                obstructions[(col, row)] = [cell]
+
+                        mt = MeshTiling(requirements, obstructions)
+                        subrules.append(mt)
+
+        return subrules
+
+    def _key(self):
+        return (self.columns, self.rows, self.requirements, self.obstructions)
+
+    def __str__(self):
+        return "{}".format(self.grid)
+
+
+def main():
+    perm = Perm((0, 2, 1))
+    mesh_patt = MeshPatt(perm, ((2, 0), (2, 1), (2, 2), (2, 3)))
+    requirements = {}
+    obstructions = {(0, 0): mesh_patt}
+    mesh_tiling = MeshTiling(requirements, obstructions)
+    max_elmnt_size = 7
+
+    print("Trying to find a cover for {} using elements up to size {}.".format(
+        mesh_tiling, max_elmnt_size))
+    comb_cov = CombCov(mesh_tiling, max_elmnt_size)
+    comb_cov.solve()
+
+    print("(Enumeration: {})".format(comb_cov.enumeration))
+
+    for nr, solution in enumerate(comb_cov.get_solutions(), start=1):
+        print("Solution nr. {}:".format(nr))
+        for rule in solution:
+            print(" - {}".format(rule))
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/mesh_tiling.py
+++ b/demo/mesh_tiling.py
@@ -34,7 +34,7 @@ class MeshTiling(Rule):
         # Constants (ToDo: make into 'cls' variables?)
         self.point = Perm((0,))
         self.point_obstruction = [Perm((0, 1)), Perm((1, 0))]
-        self.unintialized_cell = [[], []]
+        self.uninitialized_cell = [[], []]
         self.empty_cell = [[self.point], []]
         self.point_cell = [[Perm((0, 1)), Perm((1, 0))], [self.point]]
 
@@ -52,8 +52,9 @@ class MeshTiling(Rule):
         self.columns = _calc_dim(requirements, obstructions, self.x_dim) + 1
         self.rows = _calc_dim(requirements, obstructions, self.y_dim) + 1
 
-        self.requirements = requirements
-        self.obstructions = obstructions
+        self.requirements = {k: tuple(v) for (k, v) in requirements.items()}
+        self.obstructions = {k: tuple(v) for (k, v) in obstructions.items()}
+
         self.grid = [[[[] for _ in range(2)] for _ in range(self.rows)] for _
                      in range(self.columns)]
 
@@ -67,7 +68,7 @@ class MeshTiling(Rule):
 
         # ...and then the rest are empty cells
         for (c, r) in itertools.product(range(self.columns), range(self.rows)):
-            if self.grid[c][r] == self.unintialized_cell:
+            if self.grid[c][r] == self.uninitialized_cell:
                 self.grid[c][r] = self.empty_cell
 
     # Linear number = (column, row)
@@ -264,7 +265,8 @@ class MeshTiling(Rule):
         return subrules
 
     def _key(self):
-        return (self.columns, self.rows, self.requirements, self.obstructions)
+        return (frozenset(self.requirements.items()),
+                frozenset(self.obstructions.items()))
 
     def __str__(self):
         return "{}".format(self.grid)

--- a/demo/string_set.py
+++ b/demo/string_set.py
@@ -82,6 +82,7 @@ class StringSet(Rule):
                                           prefix)
                 rules.append(substring_set)
 
+        print("[INFO] Total of {} subrules".format(len(rules)))
         return rules
 
     def _key(self):
@@ -97,19 +98,18 @@ def main():
     alphabet = ('a', 'b')
     avoid = frozenset(['aa'])
     string_set = StringSet(alphabet, avoid)
-    max_elmnt_size = 7
 
-    print("Trying to find a cover for {} using elements up to size {}.".format(
-        string_set, max_elmnt_size))
+    max_elmnt_size = 7
     comb_cov = CombCov(string_set, max_elmnt_size)
     comb_cov.solve()
 
-    print("(Enumeration: {})".format(comb_cov.enumeration))
-
+    print("Enumeration: {}".format(comb_cov.enumeration))
     for nr, solution in enumerate(comb_cov.get_solutions(), start=1):
         print("Solution nr. {}:".format(nr))
-        for rule in solution:
-            print(" - {}".format(rule))
+        for i, rule in enumerate(solution, start=1):
+            bitstring = comb_cov.rules_to_bitstring_dict[rule]
+            print(" - Rule #{}: {} with bitstring {}".format(
+                i, rule, bitstring))
 
 
 if __name__ == "__main__":

--- a/demo/string_set.py
+++ b/demo/string_set.py
@@ -103,7 +103,6 @@ def main():
     comb_cov = CombCov(string_set, max_elmnt_size)
     comb_cov.solve()
 
-    print("Enumeration: {}".format(comb_cov.enumeration))
     for nr, solution in enumerate(comb_cov.get_solutions(), start=1):
         print("Solution nr. {}:".format(nr))
         for i, rule in enumerate(solution, start=1):

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 test=pytest
 
 [tool:pytest]
-addopts = --pep8 --isort --cov=combcov --cov-report=term-missing
+addopts = --pep8 --cov=combcov --cov-report=term-missing
 testpaths = demo combcov tests

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     ],
     python_requires=">=3.5",
     classifiers=[
-        "Development Status :: 2 - Pre-Alpha",
+        "Development Status :: 3 - Alpha",
         "Intended Audience :: Education",
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",

--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,13 @@ setup(
     long_description_content_type="text/markdown",
     setup_requires=["pytest-runner==5.1"],
     tests_require=[
+        # Unittests
         "pytest==4.6.2",
         "pytest-cov==2.7.1",
         "pytest-pep8==1.0.6",
         "pytest-isort==0.3.1",
+        # Demos
+        "permuta==1.0.0",
     ],
     python_requires=">=3.5",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name="CombCov",
-    version="0.0.2",
+    version="0.1.0",
     author="Permuta Triangle",
     author_email="permutatriangle@gmail.com",
     description="Searching for combinatorial covers.",
@@ -42,7 +42,6 @@ setup(
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 
-        "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/tests/test_comb_cov.py
+++ b/tests/test_comb_cov.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch
 
 from combcov import CombCov, ExactCover
-from demo import StringSet
+from demo.string_set import StringSet
 
 
 class CombCovTest(unittest.TestCase):

--- a/tests/test_mesh_tiling.py
+++ b/tests/test_mesh_tiling.py
@@ -1,6 +1,7 @@
 import unittest
 
 import pytest
+
 from demo import MeshTiling
 from demo.mesh_tiling import MockAvMeshPatt
 from permuta import Av, MeshPatt, Perm

--- a/tests/test_mesh_tiling.py
+++ b/tests/test_mesh_tiling.py
@@ -37,11 +37,17 @@ class MeshTilingTest(unittest.TestCase):
         }
         self.sub_mt = MeshTiling(self.sub_requirements, self.sub_obstructions)
 
-    def test_requirements_and_obstructions(self):
-        assert (self.root_mt.requirements == self.requirements)
-        assert (self.root_mt.obstructions == self.obstructions)
-        assert (self.sub_mt.requirements == self.sub_requirements)
-        assert (self.sub_mt.obstructions == self.sub_obstructions)
+    def test_requirements(self):
+        for coord, requirements in self.sub_requirements.items():
+            assert (coord in self.sub_mt.requirements)
+            for requirement in requirements:
+                assert (requirement in self.sub_mt.requirements[coord])
+
+    def test_obstructions(self):
+        for coord, obstructions in self.sub_obstructions.items():
+            assert (coord in self.sub_mt.obstructions)
+            for obstruction in obstructions:
+                assert (obstruction in self.sub_mt.obstructions[coord])
 
     def test_rows_and_columns(self):
         assert (self.empty_mt.columns == 1)

--- a/tests/test_mesh_tiling.py
+++ b/tests/test_mesh_tiling.py
@@ -1,0 +1,173 @@
+import unittest
+
+import pytest
+from demo import MeshTiling
+from demo.mesh_tiling import MockAvMeshPatt
+from permuta import Av, MeshPatt, Perm
+
+
+class MeshTilingTest(unittest.TestCase):
+
+    def setUp(self):
+        self.p_312 = Perm((2, 0, 1))
+        self.mp_31c2 = MeshPatt(self.p_312, ((2, 0), (2, 1), (2, 2), (2, 3)))
+        self.mp_1c2 = self.mp_31c2.sub_mesh_pattern([1, 2])
+
+        self.point = Perm((0,))
+        self.point_obstruction = [Perm((0, 1)), Perm((1, 0))]
+        self.empty_cell = [[self.point], []]
+        self.point_cell = [[Perm((0, 1)), Perm((1, 0))], [self.point]]
+
+        self.empty_mt = MeshTiling({}, {})
+
+        self.requirements = {}
+        self.obstructions = {
+            (0, 0): [self.mp_31c2],
+        }
+        self.root_mt = MeshTiling(self.requirements, self.obstructions)
+
+        self.sub_requirements = {
+            (1, 1): [self.point],
+        }
+        self.sub_obstructions = {
+            (0, 0): [self.mp_31c2],
+            (1, 1): self.point_obstruction,
+            (2, 0): [self.mp_1c2],
+        }
+        self.sub_mt = MeshTiling(self.sub_requirements, self.sub_obstructions)
+
+    def test_requirements_and_obstructions(self):
+        assert (self.root_mt.requirements == self.requirements)
+        assert (self.root_mt.obstructions == self.obstructions)
+        assert (self.sub_mt.requirements == self.sub_requirements)
+        assert (self.sub_mt.obstructions == self.sub_obstructions)
+
+    def test_rows_and_columns(self):
+        assert (self.empty_mt.columns == 1)
+        assert (self.empty_mt.rows == 1)
+        assert (self.root_mt.columns == 1)
+        assert (self.root_mt.rows == 1)
+        assert (self.sub_mt.columns == 3)
+        assert (self.sub_mt.rows == 2)
+
+    def test_all_avoiding_perms(self):
+        mamp = MockAvMeshPatt(self.mp_1c2)
+        for length, perms in [(1, [Perm((0,))]), (2, [Perm((1, 0))]),
+                              (3, [Perm((2, 1, 0))])]:
+            assert (set(mamp.of_length(length)) == set(perms))
+
+    def test_number_to_coordinates_conversions(self):
+        assert self.sub_mt.convert_linear_number_to_coordinates(0) == (0, 0)
+        assert self.sub_mt.convert_linear_number_to_coordinates(1) == (1, 0)
+        assert self.sub_mt.convert_linear_number_to_coordinates(2) == (2, 0)
+        assert self.sub_mt.convert_linear_number_to_coordinates(3) == (0, 1)
+        assert self.sub_mt.convert_linear_number_to_coordinates(4) == (1, 1)
+        assert self.sub_mt.convert_linear_number_to_coordinates(5) == (2, 1)
+
+        for number in (-1, 6):
+            with pytest.raises(IndexError):
+                self.sub_mt.convert_linear_number_to_coordinates(number)
+
+    def test_coordinates_to_number_conversions(self):
+        assert self.sub_mt.convert_coordinates_to_linear_number(0, 0) == 0
+        assert self.sub_mt.convert_coordinates_to_linear_number(1, 0) == 1
+        assert self.sub_mt.convert_coordinates_to_linear_number(2, 0) == 2
+        assert self.sub_mt.convert_coordinates_to_linear_number(0, 1) == 3
+        assert self.sub_mt.convert_coordinates_to_linear_number(1, 1) == 4
+        assert self.sub_mt.convert_coordinates_to_linear_number(2, 1) == 5
+
+        for (col, row) in [(-1, 0), (0, -1), (3, 0), (0, 2)]:
+            with pytest.raises(IndexError):
+                self.sub_mt.convert_coordinates_to_linear_number(col, row)
+
+    def test_make_tiling(self):
+        tiling = self.sub_mt.make_tiling()
+        correct_tiling = [
+            [[self.mp_31c2], []],
+            self.empty_cell,
+            [[self.mp_1c2], []],
+            self.empty_cell,
+            self.point_cell,
+            self.empty_cell
+        ]
+        assert tiling == correct_tiling
+
+    def test_get_elmnts_of_size_mp_31c2(self):
+        mamp = MockAvMeshPatt(self.mp_31c2)
+        for size in range(0, 5):
+            expected_perms = set(mamp.of_length(size)) if size > 0 else set()
+            mt_perms = set(self.sub_mt.get_elmnts(of_size=size))
+            assert (mt_perms == expected_perms)
+
+    def test_get_elmnts_of_size_increasing(self):
+        requirements = {(1, 1): [self.point]}
+        obstructions = {
+            (0, 0): [Perm((1, 0))],
+            (1, 1): self.point_obstruction
+        }
+        mt = MeshTiling(requirements, obstructions)
+        for size in range(1, 5):
+            expected_perms = set(Av([Perm((1, 0))]).of_length(size))
+            mt_perms = set(mt.get_elmnts(of_size=size))
+            assert (mt_perms == expected_perms)
+
+    def test_get_elmnts_of_size_point(self):
+        requirements = {(0, 0): [self.point]}
+        obstructions = {(0, 0): self.point_obstruction}
+        mt = MeshTiling(requirements, obstructions)
+        for size in range(1, 5):
+            expected_perms = {Perm((0,))} if size == 1 else set()
+            mt_perms = set(mt.get_elmnts(of_size=size))
+            assert (mt_perms == expected_perms)
+
+    def test_get_elmnts_of_size_two_points(self):
+        requirements = {
+            (0, 0): [self.point],
+            (1, 1): [self.point]
+        }
+        obstructions = {
+            (0, 0): self.point_obstruction,
+            (1, 1): self.point_obstruction
+        }
+        mt = MeshTiling(requirements, obstructions)
+        for size in range(1, 5):
+            expected_perms = {Perm((0, 1))} if size == 2 else set()
+            mt_perms = set(mt.get_elmnts(of_size=size))
+            assert (mt_perms == expected_perms)
+
+    def test_permclass_from_cell(self):
+        for size in range(1, 5):
+            expected_from_empty_cell = set()
+            assert set(
+                self.root_mt.permclass_from_cell(self.empty_cell).of_length(
+                    size)) == expected_from_empty_cell
+
+            expected_from_point_cell = {Perm((0,))} if size == 1 else set()
+            assert set(
+                self.root_mt.permclass_from_cell(self.point_cell).of_length(
+                    size)) == expected_from_point_cell
+
+            mp_cell = [[self.mp_31c2], []]
+            mamp = MockAvMeshPatt(mp_cell[0])
+            expected_from_mp_cell = set(mamp.of_length(size))
+            assert set(self.root_mt.permclass_from_cell(mp_cell).of_length(
+                size)) == expected_from_mp_cell
+
+    def test_is_point(self):
+        assert self.root_mt.is_point(self.point_cell)
+        assert self.root_mt.is_point(
+            [[Perm((0, 1)), Perm((1, 0))], [Perm((0,))]])
+
+    def test_is_not_point(self):
+        assert not self.root_mt.is_point(self.empty_cell)
+        assert not self.root_mt.is_point(
+            [[Perm((0, 1)), Perm((1, 0))], Perm((0,))])
+
+    def test_subrules(self):
+        subrules = self.root_mt.get_subrules()
+        assert (self.sub_mt in subrules)
+        assert (self.empty_mt in subrules)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_mesh_tiling.py
+++ b/tests/test_mesh_tiling.py
@@ -169,6 +169,10 @@ class MeshTilingTest(unittest.TestCase):
         assert (self.sub_mt in subrules)
         assert (self.empty_mt in subrules)
 
+    def test_is_hashable(self):
+        print("[INFO] self.root_mt._key(): {}".format(self.root_mt._key()))
+        self.root_mt.__hash__()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_mesh_tiling.py
+++ b/tests/test_mesh_tiling.py
@@ -25,48 +25,43 @@ class CellTest(unittest.TestCase):
     def setUp(self):
         self.mp_31c2 = MeshPatt(Perm((2, 0, 1)),
                                 ((2, 0), (2, 1), (2, 2), (2, 3)))
-        self.uninitialized_cell = Cell(None, None)
-        self.empty_cell = Cell(frozenset({Perm((0,))}), frozenset())
-        self.point_cell = Cell(frozenset({Perm((0, 1)), Perm((1, 0))}),
-                               frozenset({Perm((0,))}))
-        self.anything_cell = Cell(frozenset(), frozenset())
 
     def uninitialized_cell(self):
-        assert (self.uninitialized_cell.is_uninitialized())
-        assert (not self.empty_cell.is_uninitialized())
-        assert (not self.point_cell.is_uninitialized())
-        assert (not self.anything_cell.is_uninitialized())
+        assert (MeshTiling.uninitialized_cell.is_uninitialized())
+        assert (not MeshTiling.empty_cell.is_uninitialized())
+        assert (not MeshTiling.point_cell.is_uninitialized())
+        assert (not MeshTiling.anything_cell.is_uninitialized())
 
     def test_empty_cell(self):
-        assert (not self.uninitialized_cell.is_empty())
-        assert (self.empty_cell.is_empty())
-        assert (not self.point_cell.is_empty())
-        assert (not self.anything_cell.is_empty())
+        assert (not MeshTiling.uninitialized_cell.is_empty())
+        assert (MeshTiling.empty_cell.is_empty())
+        assert (not MeshTiling.point_cell.is_empty())
+        assert (not MeshTiling.anything_cell.is_empty())
 
     def test_point_cell(self):
-        assert (not self.uninitialized_cell.is_point())
-        assert (not self.empty_cell.is_point())
-        assert (self.point_cell.is_point())
-        assert (not self.anything_cell.is_point())
+        assert (not MeshTiling.uninitialized_cell.is_point())
+        assert (not MeshTiling.empty_cell.is_point())
+        assert (MeshTiling.point_cell.is_point())
+        assert (not MeshTiling.anything_cell.is_point())
 
     def test_anything_cell(self):
-        assert (not self.uninitialized_cell.is_anything())
-        assert (not self.empty_cell.is_anything())
-        assert (not self.point_cell.is_anything())
-        assert (self.anything_cell.is_anything())
+        assert (not MeshTiling.uninitialized_cell.is_anything())
+        assert (not MeshTiling.empty_cell.is_anything())
+        assert (not MeshTiling.point_cell.is_anything())
+        assert (MeshTiling.anything_cell.is_anything())
 
     def test_get_permclass(self):
         for size in range(1, 5):
             expected_from_empty_cell = set()
-            assert set(self.empty_cell.get_permclass().of_length(
+            assert set(MeshTiling.empty_cell.get_permclass().of_length(
                 size)) == expected_from_empty_cell
 
             expected_from_point_cell = {Perm((0,))} if size == 1 else set()
-            assert set(self.point_cell.get_permclass().of_length(
+            assert set(MeshTiling.point_cell.get_permclass().of_length(
                 size)) == expected_from_point_cell
 
             expected_from_anything_cell = set(PermSet(size))
-            assert set(self.anything_cell.get_permclass().of_length(
+            assert set(MeshTiling.anything_cell.get_permclass().of_length(
                 size)) == expected_from_anything_cell
 
             mp_cell = Cell({self.mp_31c2}, {})
@@ -87,14 +82,8 @@ class MeshTilingTest(unittest.TestCase):
         self.mp_31c2 = MeshPatt(self.p_312, ((2, 0), (2, 1), (2, 2), (2, 3)))
         self.mp_1c2 = self.mp_31c2.sub_mesh_pattern([1, 2])
 
-        self.point = Perm((0,))
+        self.point = {Perm((0,))}
         self.point_obstruction = {Perm((0, 1)), Perm((1, 0))}
-
-        self.uninitialized_cell = Cell(None, None)
-        self.empty_cell = Cell(frozenset({Perm((0,))}), frozenset())
-        self.point_cell = Cell(frozenset({Perm((0, 1)), Perm((1, 0))}),
-                               frozenset({Perm((0,))}))
-        self.anything_cell = Cell(frozenset(), frozenset())
 
         self.empty_mt = MeshTiling({}, {})
         self.root_mt = MeshTiling(
@@ -110,7 +99,7 @@ class MeshTilingTest(unittest.TestCase):
                 (2, 0): {self.mp_1c2},
             },
             requirements={
-                (1, 1): {self.point},
+                (1, 1): self.point,
             }
         )
 
@@ -147,16 +136,16 @@ class MeshTilingTest(unittest.TestCase):
         tiling = self.sub_mt.get_tiling()
         correct_tiling = [
             Cell({self.mp_31c2}, {}),
-            self.empty_cell,
+            MeshTiling.empty_cell,
             Cell({self.mp_1c2}, {}),
-            self.empty_cell,
-            self.point_cell,
-            self.empty_cell
+            MeshTiling.empty_cell,
+            MeshTiling.point_cell,
+            MeshTiling.empty_cell
         ]
         assert tiling == correct_tiling
 
     def test_get_elmnts_of_size_Av21_cell(self):
-        requirements = {(1, 1): {self.point}}
+        requirements = {(1, 1): self.point}
         obstructions = {
             (0, 0): {Perm((1, 0))},
             (1, 1): self.point_obstruction
@@ -169,7 +158,7 @@ class MeshTilingTest(unittest.TestCase):
             assert (set(mt_perms) == expected_perms)
 
     def test_get_elmnts_of_size_point_cell(self):
-        requirements = {(0, 0): {self.point}}
+        requirements = {(0, 0): self.point}
         obstructions = {(0, 0): self.point_obstruction}
         mt = MeshTiling(obstructions, requirements)
         for size in range(1, 5):

--- a/tests/test_mesh_tiling.py
+++ b/tests/test_mesh_tiling.py
@@ -35,22 +35,22 @@ class MeshTilingTest(unittest.TestCase):
         self.avoiding_nothing_cell = [[], []]
 
         self.empty_mt = MeshTiling({}, {})
-
-        self.requirements = {}
-        self.obstructions = {
-            (0, 0): [self.mp_31c2],
-        }
-        self.root_mt = MeshTiling(self.requirements, self.obstructions)
-
-        self.sub_requirements = {
-            (1, 1): [self.point],
-        }
-        self.sub_obstructions = {
-            (0, 0): [self.mp_31c2],
-            (1, 1): self.point_obstruction,
-            (2, 0): [self.mp_1c2],
-        }
-        self.sub_mt = MeshTiling(self.sub_requirements, self.sub_obstructions)
+        self.root_mt = MeshTiling(
+            obstructions={
+                (0, 0): [self.mp_31c2]
+            },
+            requirements={}
+        )
+        self.sub_mt = MeshTiling(
+            obstructions={
+                (0, 0): [self.mp_31c2],
+                (1, 1): self.point_obstruction,
+                (2, 0): [self.mp_1c2],
+            },
+            requirements={
+                (1, 1): [self.point],
+            }
+        )
 
     def test_is_instance_of_Rule(self):
         assert isinstance(self.sub_mt, Rule)
@@ -99,7 +99,7 @@ class MeshTilingTest(unittest.TestCase):
             (0, 0): [Perm((1, 0))],
             (1, 1): self.point_obstruction
         }
-        mt = MeshTiling(requirements, obstructions)
+        mt = MeshTiling(obstructions, requirements)
         for size in range(1, 5):
             expected_perms = set(Av([Perm((1, 0))]).of_length(size))
             mt_perms = mt.get_elmnts(of_size=size)
@@ -109,7 +109,7 @@ class MeshTilingTest(unittest.TestCase):
     def test_get_elmnts_of_size_point_cell(self):
         requirements = {(0, 0): [self.point]}
         obstructions = {(0, 0): self.point_obstruction}
-        mt = MeshTiling(requirements, obstructions)
+        mt = MeshTiling(obstructions, requirements)
         for size in range(1, 5):
             expected_perms = {Perm((0,))} if size == 1 else set()
             mt_perms = mt.get_elmnts(of_size=size)
@@ -184,5 +184,5 @@ class MeshTilingTest(unittest.TestCase):
         self.root_mt.__hash__()
         self.empty_mt.__hash__()
 
-    if __name__ == '__main__':
-        unittest.main()
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_mesh_tiling.py
+++ b/tests/test_mesh_tiling.py
@@ -1,7 +1,6 @@
 import unittest
 
 import pytest
-
 from demo import MeshTiling
 from demo.mesh_tiling import MockAvMeshPatt
 from permuta import Av, MeshPatt, Perm

--- a/tests/test_mesh_tiling.py
+++ b/tests/test_mesh_tiling.py
@@ -7,6 +7,20 @@ from demo.mesh_tiling import MockAvMeshPatt
 from permuta import Av, MeshPatt, Perm, PermSet
 
 
+class MockAvMeshPattTests(unittest.TestCase):
+
+    def test_mock_av_patt_nonsense(self):
+        with pytest.raises(ValueError):
+            MockAvMeshPatt([None])
+
+    def test_all_avoiding_perms(self):
+        mp_1c2 = MeshPatt(Perm((0, 1)), ((1, 0), (1, 1), (1, 2)))
+        mamp = MockAvMeshPatt(mp_1c2)
+        for length, perms in [(1, [Perm((0,))]), (2, [Perm((1, 0))]),
+                              (3, [Perm((2, 1, 0))])]:
+            assert (set(mamp.of_length(length)) == set(perms))
+
+
 class MeshTilingTest(unittest.TestCase):
 
     def setUp(self):
@@ -42,36 +56,6 @@ class MeshTilingTest(unittest.TestCase):
         assert isinstance(self.sub_mt, Rule)
         assert isinstance(self.root_mt, Rule)
         assert isinstance(self.empty_mt, Rule)
-
-    # Bad unittest as it tests the implementation and not the interface
-    def test_requirements(self):
-        for coord, requirements in self.sub_requirements.items():
-            assert (coord in self.sub_mt.requirements)
-            for requirement in requirements:
-                assert (requirement in self.sub_mt.requirements[coord])
-
-    # Bad unittest as it tests the implementation and not the interface
-    def test_obstructions(self):
-        for coord, obstructions in self.sub_obstructions.items():
-            assert (coord in self.sub_mt.obstructions)
-            for obstruction in obstructions:
-                assert (obstruction in self.sub_mt.obstructions[coord])
-
-    # Bad unittest as it tests the implementation and not the interface
-    # ToDo: Implement and test a MeshTiling.get_dimenstion() function instead
-    def test_rows_and_columns(self):
-        assert (self.empty_mt.columns == 1)
-        assert (self.empty_mt.rows == 1)
-        assert (self.root_mt.columns == 1)
-        assert (self.root_mt.rows == 1)
-        assert (self.sub_mt.columns == 3)
-        assert (self.sub_mt.rows == 2)
-
-    def test_all_avoiding_perms(self):
-        mamp = MockAvMeshPatt(self.mp_1c2)
-        for length, perms in [(1, [Perm((0,))]), (2, [Perm((1, 0))]),
-                              (3, [Perm((2, 1, 0))])]:
-            assert (set(mamp.of_length(length)) == set(perms))
 
     def test_number_to_coordinates_conversions(self):
         assert self.sub_mt.convert_linear_number_to_coordinates(0) == (0, 0)
@@ -109,7 +93,7 @@ class MeshTilingTest(unittest.TestCase):
         ]
         assert tiling == correct_tiling
 
-    def test_get_elmnts_of_size_increasing(self):
+    def test_get_elmnts_of_size_Av21_cell(self):
         requirements = {(1, 1): [self.point]}
         obstructions = {
             (0, 0): [Perm((1, 0))],
@@ -122,7 +106,7 @@ class MeshTilingTest(unittest.TestCase):
             assert (len(set(mt_perms)) == len(list(mt_perms)))
             assert (set(mt_perms) == expected_perms)
 
-    def test_get_elmnts_of_size_point(self):
+    def test_get_elmnts_of_size_point_cell(self):
         requirements = {(0, 0): [self.point]}
         obstructions = {(0, 0): self.point_obstruction}
         mt = MeshTiling(requirements, obstructions)
@@ -150,8 +134,10 @@ class MeshTilingTest(unittest.TestCase):
                 size)) == expected_from_anything_cell
 
             mp_cell = [[self.mp_31c2], []]
-            mamp = MockAvMeshPatt(mp_cell[0])
-            expected_from_mp_cell = mamp.of_length(size)
+            expected_from_mp_cell = set(filter(
+                lambda perm: perm.avoids(self.mp_31c2),
+                PermSet(size))
+            )
             assert set(self.root_mt.permclass_from_cell(mp_cell).of_length(
                 size)) == set(expected_from_mp_cell)
             assert (len(set(expected_from_mp_cell)) ==
@@ -182,6 +168,16 @@ class MeshTilingTest(unittest.TestCase):
         self.root_mt.MAX_ACTIVE_CELLS = 3
         subrules = self.root_mt.get_subrules()
         assert (self.sub_mt not in subrules)
+
+    def test_dimensions(self):
+        assert (self.sub_mt.get_dimension() == (3, 2))
+        assert (self.root_mt.get_dimension() == (1, 1))
+        assert (self.empty_mt.get_dimension() == (1, 1))
+
+    def test_length(self):
+        assert (len(self.sub_mt) == 6)
+        assert (len(self.root_mt) == 1)
+        assert (len(self.empty_mt) == 1)
 
     def test_is_hashable(self):
         self.sub_mt.__hash__()


### PR DESCRIPTION
PR deploys version `0.1.0` to Pypi with the following new demo:
```bash
$ python -m demo.mesh_tiling
[INFO] Total of 76 elements of size up to 5
[INFO] Enumeration: [1, 1, 2, 5, 15, 52]
[INFO] Bitstring to cover: 75557863725914323419135 
[INFO] Total of 1077 subrules
[INFO] Trying to find a cover for 
 -----------------------------------------------------------------
| Av(MeshPatt(Perm((2, 0, 1)), [(2, 0), (2, 1), (2, 2), (2, 3)])) |
 -----------------------------------------------------------------
 using elements up to size 5.
Solution nr. 1:
Rule #1 of dimension 1x1 with bitstring 1: 
 ---
|   |
 ---

Rule #2 of dimension 3x2 with bitstring 75557863725914323419134: 
 ----------------------------------------------------------------------------------------------------------------------------
|                                                                 | o |                                                      |
|-----------------------------------------------------------------+---+------------------------------------------------------|
| Av(MeshPatt(Perm((2, 0, 1)), [(2, 0), (2, 1), (2, 2), (2, 3)])) |   | Av(MeshPatt(Perm((0, 1)), [(1, 0), (1, 1), (1, 2)])) |
 ----------------------------------------------------------------------------------------------------------------------------

```