### PR TITLE
Make 'CombCov.get_subrules()' a generator

### DIFF
--- a/demo/string_set.py
+++ b/demo/string_set.py
@@ -1,6 +1,5 @@
 import itertools
 import logging
-from typing import List
 
 from combcov import CombCov, Rule
 
@@ -66,8 +65,8 @@ class StringSet(Rule):
 
         return strings_of_length
 
-    def get_subrules(self) -> List[Rule]:
-        rules = []
+    def get_subrules(self):
+        rules = 0
         prefixes = []
         for n in range(self.max_prefix_size):
             prefixes.extend(self.get_elmnts(n + 1))
@@ -77,17 +76,18 @@ class StringSet(Rule):
             empty_string_set = StringSet(alphabet=self.alphabet,
                                          avoid=frozenset(self.alphabet),
                                          prefix=prefix)
-            rules.append(empty_string_set)
+            rules += 1
+            yield empty_string_set
 
         # Regular rules of the from prefix + non-empty StringSet
         for prefix in prefixes:
             for avoiding_subset in self.get_all_avoiding_subsets():
                 substring_set = StringSet(self.alphabet, avoiding_subset,
                                           prefix)
-                rules.append(substring_set)
+                rules += 1
+                yield substring_set
 
-        logger.info("Generated {} subrules".format(len(rules)))
-        return rules
+        logger.info("Generated {} subrules".format(rules))
 
     def _key(self):
         return (self.alphabet, self.avoid, self.prefix)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name="CombCov",
-    version="0.3.0",
+    version="0.3.1",
     author="Permuta Triangle",
     author_email="permutatriangle@gmail.com",
     description="Searching for combinatorial covers.",

--- a/tests/test_comb_cov.py
+++ b/tests/test_comb_cov.py
@@ -54,7 +54,7 @@ class CombCovTest(unittest.TestCase):
             assert len(mocked_print.mock_calls) == 1
 
     def test_too_many_subrules(self) -> None:
-        subrules = self.string_set.get_subrules()
+        subrules = list(self.string_set.get_subrules())
         too_many = subrules + [self.string_set] + subrules
 
         correct_rules = self.comb_cov.rules

--- a/tests/test_mesh_tiling.py
+++ b/tests/test_mesh_tiling.py
@@ -1,9 +1,10 @@
 import unittest
 
+from permuta import Av, MeshPatt, Perm, PermSet
+
 import pytest
 from combcov import Rule
 from demo.mesh_tiling import Cell, MeshTiling, MockAvMeshPatt
-from permuta import Av, MeshPatt, Perm, PermSet
 
 
 class MockAvMeshPattTests(unittest.TestCase):
@@ -177,7 +178,7 @@ class MeshTilingTest(unittest.TestCase):
         self.root_mt.MAX_COLUMN_DIMENSION = 3
         self.root_mt.MAX_ROW_DIMENSION = 2
         self.root_mt.MAX_ACTIVE_CELLS = 3
-        subrules = self.root_mt.get_subrules()
+        subrules = list(self.root_mt.get_subrules())
         assert all(isinstance(rule, Rule) for rule in subrules)
         assert (self.empty_mt in subrules)
         assert (self.sub_mt in subrules)
@@ -186,7 +187,7 @@ class MeshTilingTest(unittest.TestCase):
         self.root_mt.MAX_COLUMN_DIMENSION = 2
         self.root_mt.MAX_ROW_DIMENSION = 2
         self.root_mt.MAX_ACTIVE_CELLS = 3
-        subrules = self.root_mt.get_subrules()
+        subrules = list(self.root_mt.get_subrules())
         assert all(isinstance(rule, Rule) for rule in subrules)
         assert (self.empty_mt in subrules)
         assert (self.sub_mt not in subrules)


### PR DESCRIPTION
Instead of the function returning a list of all subrules, it's better to make it into a generator returning each rule as it's generated. This saves memory and opens up for the possibility of parallelising the rule generation (`MeshTiling`, `StringSet` and other such objects) and bitstring creation (`CombCov`).

Also made MeshTiling.get_subrules() a little bit smarted by discarding subrules with empty column or row as those are duplicates of other MeshTilings of lower dimension.