### PR TITLE
Original cell of 1x1 root object used as possible active cell in rule generation

### DIFF
--- a/agenda_meetings.md
+++ b/agenda_meetings.md
@@ -1,12 +1,45 @@
 2019-08-15
 ==========
-- [ ] Review EC Python library and Bjarni's homework assignments
-- [ ] Which results to replicate?
+- [x] Review EC Python library and Bjarni's homework assignments
+- [x] Which results to replicate?
       + Wilf-classification of mesh patterns of short length
       + On pattern-avoiding Fishburn permutations
       + Anything else?
 - [ ] Discuss skeleton for presentation
 - [ ] Discuss skeleton for thesis writing
+
+### Summary
+
+Henning and Christian were happy with the PyECCArithmetic library and will probably use it for homework assignments
+in the Crypto course this fall semester. The owner of the repo hasn't responded to Bjarni's PR that adds support for
+the infinity point. We discussed the possibility of releasing another package to PyPi with slightly different name if
+the owner won't respond, or instructing students to clone the repo and install via `setup.py`. Bjarni will post his
+homework solutions as a private GitHub gist and give Henning and Christian access.
+
+Some results from the Fishburn paper were replicated with CombCov (namely sigma equals to 231, 123, 132 and 213) but
+others were unsuccessful (sigma equals 312 and 321 and all of the length 4 patterns). We will try that again on Garpur
+with larger search space. We will also try all combinations with two length four patterns. The results from the Wilf
+paper that were discussed in last meeting also need to be run on Garpur with larger search space than were tried on
+Bjarni's laptop.
+
+Christian came up with yet another paper with results that is interesting to try to replicate, a paper on avoiding
+vincular and covincular patterns of length 3. We tried a result from the paper that gives the Motzkin numbers:
+```text
+         | | |       | | |   
+        -+-3-+-     -+-+-3-  
+         | | |      #|#|#|#  
+   Av(  -+-+-2-  ,  -+-2-+-  )
+         | | |       | | |   
+        -1-+-+-     -1-+-+-  
+         | | |       | | |   
+```
+At first we were unsuccessful to find a cover for it, but by editing the rule generation function to create more
+complicated rules we managed to find a cover for, albeit slightly different that in the paper. We will try to run
+CombCov again with theses changes on previously unsuccessful results from Fishburn and Wilf papers.
+
+We started discussing the layout of Bjarni's thesis but need to follow up on that in the next meeting. Henning
+mentioned that it would be smart though to rename `StringSet` to `WordSet` so the elements are called *words* and are
+not confused with the underlying *bitstrings*.
 
 
 
@@ -20,7 +53,7 @@
 
 Henning prepared reading chapters and exercises for Bjarni solve. Henning wants Bjarni to find a suitable Python
 library and solve most of the exercises with it. The idea being that Christian can use it for homework assignments
-in his crypto class this fall.
+in his Crypto class this fall.
 
 Together Bjarni and Henning hacked together the `MeshTilings.get_elmnts()` method by porting the multiple nested
 for-loops. It was ugly but it worked and we could run it on some short mesh patterns from the Wilf-classification

--- a/demo/mesh_tiling.py
+++ b/demo/mesh_tiling.py
@@ -105,12 +105,13 @@ class MeshTiling(Rule):
 
         # Populate obstructions...
         for (c, r), obs_list in self.obstructions.items():
-            self.grid[c][r] = Cell(set(obs_list), {})
+            self.grid[c][r] = Cell(frozenset(obs_list), frozenset())
 
         # ...and requirements...
         for (c, r), req_list in self.requirements.items():
             previous_obstruction_list = self.grid[c][r].obstructions
-            self.grid[c][r] = Cell(previous_obstruction_list, set(req_list))
+            self.grid[c][r] = Cell(previous_obstruction_list,
+                                   frozenset(req_list))
 
         # ...and then the rest are empty cells
         for (c, r) in itertools.product(range(self.columns), range(self.rows)):
@@ -244,7 +245,7 @@ class MeshTiling(Rule):
         # obstructions (MeshPatts) where the obstructions are sub mesh patterns
         # of any of the obstructions in the root object.
 
-        cell_choices = {self.point_cell, self.anything_cell}
+        cell_choices = {self.point_cell, self.anything_cell, self.grid[0][0]}
         for obstruction_list in self.obstructions.values():
             for obstruction in obstruction_list:
                 if isinstance(obstruction, MeshPatt):
@@ -281,6 +282,9 @@ class MeshTiling(Rule):
                     raise ValueError(
                         "[ERROR] obstruction '{}' is neither a MeshPatt "
                         "or Perm!".format(obstruction))
+
+        logger.info("{} cell_choices: {}".format(
+            len(cell_choices), cell_choices))
 
         subrules = 1
         yield MeshTiling({}, {})  # always include the empty rule

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name="CombCov",
-    version="0.3.1",
+    version="0.3.2",
     author="Permuta Triangle",
     author_email="permutatriangle@gmail.com",
     description="Searching for combinatorial covers.",

--- a/tests/test_mesh_tiling.py
+++ b/tests/test_mesh_tiling.py
@@ -26,7 +26,7 @@ class CellTest(unittest.TestCase):
     def setUp(self):
         self.mp_31c2 = MeshPatt(Perm((2, 0, 1)),
                                 ((2, 0), (2, 1), (2, 2), (2, 3)))
-        self.mp_cell = Cell({self.mp_31c2}, {})
+        self.mp_cell = Cell(frozenset({self.mp_31c2}), frozenset())
 
     def uninitialized_cell(self):
         assert (MeshTiling.uninitialized_cell.is_uninitialized())
@@ -142,9 +142,9 @@ class MeshTilingTest(unittest.TestCase):
     def test_make_tiling(self):
         tiling = self.sub_mt.get_tiling()
         correct_tiling = [
-            Cell({self.mp_31c2}, {}),
+            Cell(frozenset({self.mp_31c2}), frozenset()),
             MeshTiling.empty_cell,
-            Cell({self.mp_1c2}, {}),
+            Cell(frozenset({self.mp_1c2}), frozenset()),
             MeshTiling.empty_cell,
             MeshTiling.point_cell,
             MeshTiling.empty_cell


### PR DESCRIPTION
This was added in order to be able to replicate a result (from the chapter called Motzkin numbers) from the paper on Vincular and Covincular patterns of length 3 by Bean, Claesson and Ulfarsson. 

This might also enable us to find covers for previous unsuccessful attempts.