### PR TITLE
Covers for Co(patts)

### DIFF
--- a/combcov/combcov.py
+++ b/combcov/combcov.py
@@ -119,14 +119,11 @@ class CombCov():
                              cat="Binary")
 
         for i in range(len(self.elmnts_dict)):  # nr. of equations
-            indices_in_equation = []
-            for j in range(len(self.bitstrings)):  # nr. of variables x_j
-                if (self.bitstrings[j] & (1 << i)) != 0:
-                    indices_in_equation.append(j)
-
-            if indices_in_equation:
-                constraint = sum(X[j] for j in indices_in_equation)
-                problem += constraint == 1
+            constraint = sum(
+                int((self.bitstrings[j] & (1 << i)) != 0) * X[j]
+                for j in range(len(self.bitstrings))
+            )  # nr. of variables x_j
+            problem += constraint == 1
 
         # Objective function
         problem += sum(X[j] for j in range(len(self.bitstrings)))

--- a/combcov/combcov.py
+++ b/combcov/combcov.py
@@ -57,7 +57,7 @@ class CombCov():
         self.rules_to_bitstring_dict = {}
 
         for rule in self.root_object.get_subrules():
-            if rule in self.rules:
+            if rule == self.root_object or rule in self.rules:
                 rule_is_good = False
             else:
                 rule_is_good = True
@@ -75,10 +75,6 @@ class CombCov():
                     else:
                         seen_elmnts.add(elmnt)
                         binary_string += 2 ** (self.elmnts_dict[elmnt])
-
-                # Throwing out single-rule covers
-                if binary_string == string_to_cover:
-                    rule_is_good = False
 
             if rule_is_good:
                 self.rules.append(rule)

--- a/demo/mesh_tiling.py
+++ b/demo/mesh_tiling.py
@@ -24,6 +24,9 @@ class Cell(namedtuple('Cell', ['obstructions', 'requirements'])):
         return self.obstructions == frozenset() \
                and self.requirements == frozenset()
 
+    def flip(self):
+        return Cell(self.requirements, self.obstructions)
+
     def get_permclass(self):
         if self.is_empty():
             return Av(Perm((0,)))

--- a/demo/mesh_tiling.py
+++ b/demo/mesh_tiling.py
@@ -24,6 +24,14 @@ class Cell(namedtuple('Cell', ['obstructions', 'requirements'])):
         return self.obstructions == frozenset() \
                and self.requirements == frozenset()
 
+    def is_only_avoiding(self):
+        return len(self.obstructions) > 0 \
+               and self.requirements == frozenset()
+
+    def is_only_containing(self):
+        return self.obstructions == frozenset() \
+               and len(self.requirements) > 0
+
     def flip(self):
         return Cell(self.requirements, self.obstructions)
 
@@ -44,9 +52,16 @@ class Cell(namedtuple('Cell', ['obstructions', 'requirements'])):
             return "o"
         elif self.is_anything():
             return "S"
+        elif self.is_only_avoiding():
+            return "Av({})".format(
+                ", ".join(repr(patt) for patt in self.obstructions))
+        elif self.is_only_containing():
+            return "Co({})".format(
+                ", ".join(repr(patt) for patt in self.requirements))
         else:
-            return "Av({})".format(", ".join(
-                repr(mp) for mp in self.obstructions))
+            return "Av({}) and Co({})".format(
+                ", ".join(repr(patt) for patt in self.obstructions),
+                ", ".join(repr(patt) for patt in self.requirements))
 
     def __str__(self):
         # ToDo: Instead return multi-line mesh patterns

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     long_description=read("README.md"),
     long_description_content_type="text/markdown",
     install_requires=[
-        "permuta==1.0.0",
+        "permuta==1.1.0",
         "PuLP==1.6.10",
     ],
     setup_requires=["pytest-runner==5.1"],

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name="CombCov",
-    version="0.3.4",
+    version="0.4.0",
     author="Permuta Triangle",
     author_email="permutatriangle@gmail.com",
     description="Searching for combinatorial covers.",

--- a/tests/test_mesh_tiling.py
+++ b/tests/test_mesh_tiling.py
@@ -4,21 +4,7 @@ from permuta import Av, MeshPatt, Perm, PermSet
 
 import pytest
 from combcov import Rule
-from demo.mesh_tiling import Cell, MeshTiling, MockAvMeshPatt
-
-
-class MockAvMeshPattTests(unittest.TestCase):
-
-    def test_mock_av_patt_nonsense(self):
-        with pytest.raises(ValueError):
-            MockAvMeshPatt([None])
-
-    def test_all_avoiding_perms(self):
-        mp_1c2 = MeshPatt(Perm((0, 1)), ((1, 0), (1, 1), (1, 2)))
-        mamp = MockAvMeshPatt(mp_1c2)
-        for length, perms in [(1, [Perm((0,))]), (2, [Perm((1, 0))]),
-                              (3, [Perm((2, 1, 0))])]:
-            assert (set(mamp.of_length(length)) == set(perms))
+from demo.mesh_tiling import Cell, MeshTiling
 
 
 class CellTest(unittest.TestCase):
@@ -76,6 +62,23 @@ class CellTest(unittest.TestCase):
                 size)) == set(expected_from_mp_cell)
             assert (len(set(expected_from_mp_cell)) ==
                     len(list(expected_from_mp_cell)))
+
+
+class PermTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.p = Perm((1, 0))
+        self.mt = MeshTiling({(0, 0): Cell(
+            obstructions=frozenset({self.p}),
+            requirements=frozenset()
+        )})
+
+    def test_that_obstructions_are_perms(self) -> None:
+        for subrule in self.mt.get_subrules():
+            assert isinstance(subrule, Rule)
+            for obstructions in subrule.get_obstruction_lists():
+                for obstruction in obstructions:
+                    assert isinstance(obstruction, Perm)
 
 
 class MeshTilingTest(unittest.TestCase):

--- a/tests/test_mesh_tiling.py
+++ b/tests/test_mesh_tiling.py
@@ -34,6 +34,10 @@ class CellTest(unittest.TestCase):
         assert repr(MeshTiling.point_cell) == "o"
         assert repr(MeshTiling.anything_cell) == "S"
         assert repr(self.mp_cell) == "Av({})".format(repr(self.mp_31c2))
+        assert repr(self.mp_cell.flip()) == "Co({})".format(repr(self.mp_31c2))
+        av_co_cell = Cell(frozenset({self.mp_31c2}), frozenset({self.mp_31c2}))
+        assert repr(av_co_cell) == "Av({}) and Co({})".format(
+            repr(self.mp_31c2), repr(self.mp_31c2))
 
     def test_flip(self):
         flipped_cell = Cell(frozenset(), frozenset({self.mp_31c2}))
@@ -68,14 +72,10 @@ class PermTest(unittest.TestCase):
 
     def setUp(self) -> None:
         self.p = Perm((1, 0))
-        self.mt = MeshTiling({(0, 0): Cell(
-            obstructions=frozenset({self.p}),
-            requirements=frozenset()
-        )})
+        self.mt = MeshTiling({(0, 0): Cell(frozenset({self.p}), frozenset())})
 
     def test_that_obstructions_are_perms(self) -> None:
         for subrule in self.mt.get_subrules():
-            assert isinstance(subrule, Rule)
             for obstructions in subrule.get_obstruction_lists():
                 for obstruction in obstructions:
                     assert isinstance(obstruction, Perm)
@@ -156,16 +156,16 @@ class MeshTilingTest(unittest.TestCase):
         ]
         assert tiling == correct_tiling
 
+    def test_invalid_obstruction(self):
+        invalid_cell = Cell(frozenset({"not a mesh patt"}), frozenset())
+        invalid_mt = MeshTiling({(0, 0): invalid_cell})
+        with pytest.raises(ValueError):
+            list(invalid_mt.get_subrules())
+
     def test_get_elmnts_of_size_Av21_cell(self):
         mt = MeshTiling({
-            (0, 0): Cell(
-                obstructions=frozenset({Perm((1, 0))}),
-                requirements=frozenset()
-            ),
-            (1, 1): Cell(
-                obstructions=frozenset({Perm((0, 1)), Perm((1, 0))}),
-                requirements=frozenset({Perm((0,))})
-            )
+            (0, 0): Cell(frozenset({Perm((1, 0))}), frozenset()),
+            (1, 1): MeshTiling.point_cell
         })
 
         for size in range(1, 5):
@@ -176,10 +176,7 @@ class MeshTilingTest(unittest.TestCase):
 
     def test_get_elmnts_of_size_point_cell(self):
         mt = MeshTiling({
-            (0, 0): Cell(
-                obstructions=frozenset({Perm((0, 1)), Perm((1, 0))}),
-                requirements=frozenset({Perm((0,))})
-            )
+            (0, 0): MeshTiling.point_cell
         })
 
         for size in range(1, 5):

--- a/tests/test_mesh_tiling.py
+++ b/tests/test_mesh_tiling.py
@@ -14,11 +14,6 @@ class CellTest(unittest.TestCase):
                                 ((2, 0), (2, 1), (2, 2), (2, 3)))
         self.mp_cell = Cell(frozenset({self.mp_31c2}), frozenset())
 
-    def uninitialized_cell(self):
-        assert (not MeshTiling.empty_cell.is_uninitialized())
-        assert (not MeshTiling.point_cell.is_uninitialized())
-        assert (not MeshTiling.anything_cell.is_uninitialized())
-
     def test_empty_cell(self):
         assert (MeshTiling.empty_cell.is_empty())
         assert (not MeshTiling.point_cell.is_empty())
@@ -39,6 +34,11 @@ class CellTest(unittest.TestCase):
         assert repr(MeshTiling.point_cell) == "o"
         assert repr(MeshTiling.anything_cell) == "S"
         assert repr(self.mp_cell) == "Av({})".format(repr(self.mp_31c2))
+
+    def test_flip(self):
+        flipped_cell = Cell(frozenset(), frozenset({self.mp_31c2}))
+        assert flipped_cell == self.mp_cell.flip()
+        assert self.mp_cell == self.mp_cell.flip().flip()
 
     def test_get_permclass(self):
         for size in range(1, 5):


### PR DESCRIPTION
Adding support for finding "containment covers" i.e. covers for cells with non-empty requirements, e.g.
```text
                                                              ------- 
 ----------------------------------------------------        |   | S |
| Co(MeshPatt(Perm((0,)), [(0, 0), (0, 1), (1, 0)])) |   =   |---+---|
 ----------------------------------------------------        | o |   |
                                                              ------- 
```
in contrast what we already could find:
```text
                                                              ------- 
 ----------------------------------------------------        | o | S |
| Av(MeshPatt(Perm((0,)), [(0, 0), (0, 1), (1, 0)])) |   =   |---+---|
 ----------------------------------------------------        |   | o |
                                                              ------- 
```
