### PR TITLE
Ignore empty cells in input to MeshTiling

### DIFF
--- a/demo/mesh_tiling.py
+++ b/demo/mesh_tiling.py
@@ -134,7 +134,8 @@ class MeshTiling(Rule):
         self.MAX_ACTIVE_CELLS = 3
 
         # Clean empty rows and columns and save cells with shifted coordinates
-        Xs, Ys = set(x for (x, y) in cells), set(y for (x, y) in cells)
+        Xs = set(x for (x, y) in cells if not cells[(x, y)].is_empty())
+        Ys = set(y for (x, y) in cells if not cells[(x, y)].is_empty())
         self.columns, self.rows = max(1, len(Xs)), max(1, len(Ys))
 
         compression_dict = {
@@ -145,11 +146,12 @@ class MeshTiling(Rule):
         self.cells = {}
         self.tiling = [self.empty_cell] * (self.columns * self.rows)
         for (old_col, old_row), cell in cells.items():
-            col = compression_dict['col'][old_col]
-            row = compression_dict['row'][old_row]
-            self.cells[(col, row)] = cell
-            self.tiling[
-                self.convert_coordinates_to_linear_number(col, row)] = cell
+            if not cell.is_empty():
+                col = compression_dict['col'][old_col]
+                row = compression_dict['row'][old_row]
+                self.cells[(col, row)] = cell
+                self.tiling[
+                    self.convert_coordinates_to_linear_number(col, row)] = cell
 
     # Linear number = (column, row)
     #   -----------------------------------

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name="CombCov",
-    version="0.6.0",
+    version="0.6.1",
     author="Permuta Triangle",
     author_email="permutatriangle@gmail.com",
     description="Searching for combinatorial covers.",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     ],
     setup_requires=["pytest-runner==5.1"],
     tests_require=[
-        "pytest==5.1.1",
+        "pytest==5.1.2",
         "pytest-cov==2.7.1",
         "pytest-pep8==1.0.6",
         "pytest-isort==0.3.1",

--- a/tests/test_mesh_tiling.py
+++ b/tests/test_mesh_tiling.py
@@ -217,6 +217,13 @@ class MeshTilingTest(unittest.TestCase):
         with pytest.raises(ValueError):
             list(invalid_mt.get_subrules())
 
+    def test_extra_empty_cell(self):
+        root_mt_with_extra_empty_cell = MeshTiling({
+            (0, 0): self.root_mp_cell,
+            (1, 1): MeshTiling.empty_cell
+        })
+        assert self.root_mt == root_mt_with_extra_empty_cell
+
     def test_get_elmnts_of_size_Av21_cell(self):
         mt = MeshTiling({
             (0, 0): Cell(frozenset({Perm((1, 0))}), frozenset()),


### PR DESCRIPTION
The outcome should be the same with and without the empty cell(s).