### PR TITLE
Properly handling mixes of Perms and MeshPatts

### DIFF
--- a/demo/mesh_tiling.py
+++ b/demo/mesh_tiling.py
@@ -154,13 +154,13 @@ class MeshTiling(Rule):
                 self.tiling[
                     self.convert_coordinates_to_linear_number(col, row)] = cell
 
-    # Linear number = (column, row)
-    #   -----------------------------------
-    #  | 3 = (0,1) | 4 = (1,1) | 5 = (2,1) |
-    #  |-----------+-----------+-----------|
-    #  | 0 = (0,0) | 1 = (1,0) | 2 = (2,0) |
-    #   -----------------------------------
     def convert_linear_number_to_coordinates(self, number):
+        # Linear number = (column, row)
+        #   -----------------------------------
+        #  | 3 = (0,1) | 4 = (1,1) | 5 = (2,1) |
+        #  |-----------+-----------+-----------|
+        #  | 0 = (0,0) | 1 = (1,0) | 2 = (2,0) |
+        #   -----------------------------------
         if number < 0 or number >= self.columns * self.rows:
             raise IndexError
         else:

--- a/demo/mesh_tiling.py
+++ b/demo/mesh_tiling.py
@@ -2,9 +2,10 @@ import logging
 from collections import deque, namedtuple
 from itertools import chain, combinations, product
 
-from combcov import CombCov, Rule
 from permuta import Av, MeshPatt, Perm, PermSet
 from permuta.misc import flatten, ordered_set_partitions
+
+from combcov import CombCov, Rule
 
 logger = logging.getLogger("MeshTiling")
 
@@ -69,8 +70,8 @@ class Cell(namedtuple('Cell', ['obstructions', 'requirements'])):
         elif self.is_anything():
             return "S"
         else:
-            Avs = ", ".join(repr(patt) for patt in sorted(self.obstructions))
-            Cos = ", ".join(repr(patt) for patt in sorted(self.requirements))
+            Avs = ", ".join(repr(p) for p in Utils.sorted(self.obstructions))
+            Cos = ", ".join(repr(p) for p in Utils.sorted(self.requirements))
             if self.is_avoiding() and not self.is_containing():
                 return "Av({})".format(Avs)
             elif self.is_containing() and not self.is_avoiding():
@@ -91,14 +92,14 @@ class Cell(namedtuple('Cell', ['obstructions', 'requirements'])):
                 Utils.pad_string_to_rectangle(
                     str(patt if isinstance(patt, MeshPatt) else
                         MeshPatt(patt, [])), dim, dim
-                ).split("\n") for patt in sorted(self.obstructions)
+                ).split("\n") for patt in Utils.sorted(self.obstructions)
             ]
 
             Co_strings = [
                 Utils.pad_string_to_rectangle(
                     str(patt if isinstance(patt, MeshPatt) else
                         MeshPatt(patt, [])), dim, dim
-                ).split("\n") for patt in sorted(self.requirements)
+                ).split("\n") for patt in Utils.sorted(self.requirements)
             ]
 
             lines = ["" for _ in range(dim)]
@@ -459,6 +460,12 @@ class Utils():
                 new_lines.appendleft(empty_line)
 
         return "\n".join(line for line in new_lines)
+
+    @staticmethod
+    def sorted(mixed_patts):
+        perms = filter(lambda perm: isinstance(perm, Perm), mixed_patts)
+        mpatts = filter(lambda mpatt: isinstance(mpatt, MeshPatt), mixed_patts)
+        yield from chain(sorted(perms), sorted(mpatts))
 
 
 def main():

--- a/demo/mesh_tiling.py
+++ b/demo/mesh_tiling.py
@@ -85,26 +85,26 @@ class Cell(namedtuple('Cell', ['obstructions', 'requirements'])):
         else:
             # String representation of mesh patts are a (2N + 1) x (2N + 1)
             # matrix where N is the length of the underlying permutation
-            dim = 1 + 2 * max(len(patt) for patt in chain(self.obstructions,
-                                                          self.requirements))
+            height = 1 + 2 * max(len(patt) for patt in chain(
+                                        self.obstructions, self.requirements))
 
             Av_strings = [
                 Utils.pad_string_to_rectangle(
                     str(patt if isinstance(patt, MeshPatt) else
-                        MeshPatt(patt, [])), dim, dim
+                        MeshPatt(patt, [])), 1 + 2 * len(patt), height
                 ).split("\n") for patt in Utils.sorted(self.obstructions)
             ]
 
             Co_strings = [
                 Utils.pad_string_to_rectangle(
                     str(patt if isinstance(patt, MeshPatt) else
-                        MeshPatt(patt, [])), dim, dim
+                        MeshPatt(patt, [])), 1 + 2 * len(patt), height
                 ).split("\n") for patt in Utils.sorted(self.requirements)
             ]
 
-            lines = ["" for _ in range(dim)]
-            for row in range(dim):
-                middle_row = (row == (dim - 1) / 2)
+            lines = ["" for _ in range(height)]
+            for row in range(height):
+                middle_row = (row == (height - 1) / 2)
                 if middle_row:
                     prefix, delim, postfix = "{}( ", " , ", " )"
                 else:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name="CombCov",
-    version="0.6.1",
+    version="0.6.2",
     author="Permuta Triangle",
     author_email="permutatriangle@gmail.com",
     description="Searching for combinatorial covers.",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     long_description=read("README.md"),
     long_description_content_type="text/markdown",
     install_requires=[
-        "permuta==1.2.0",
+        "permuta==1.2.1",
         "PuLP==1.6.10",
     ],
     setup_requires=["pytest-runner==5.1"],

--- a/tests/test_mesh_tiling.py
+++ b/tests/test_mesh_tiling.py
@@ -2,10 +2,11 @@ import unittest
 from itertools import combinations, product
 from math import factorial
 
+from permuta import Av, MeshPatt, Perm, PermSet
+
 import pytest
 from combcov import Rule
 from demo.mesh_tiling import Cell, MeshTiling, MockAvCoPatts, Utils
-from permuta import Av, MeshPatt, Perm, PermSet
 
 
 class MockContainingPattsTest(unittest.TestCase):
@@ -35,7 +36,10 @@ class CellTest(unittest.TestCase):
                                 ((2, 0), (2, 1), (2, 2), (2, 3)))
         self.mp_cell = Cell(frozenset({self.mp_31c2}), frozenset())
         self.mixed_av_co_cell = Cell(
-            frozenset({Perm((0, 2, 1)), Perm((2, 0, 1))}),
+            frozenset({
+                Perm((0, 2, 1)),
+                MeshPatt(Perm((1, 0)), [(0, 0), (1, 1), (2, 2)])
+            }),
             frozenset({Perm((0, 1))})
         )
 
@@ -86,13 +90,13 @@ class CellTest(unittest.TestCase):
             "    -+-0-+-  \n"
             "     | |#|   ")
         assert str(self.mixed_av_co_cell) == (
-            "     | | |     | | |                     \n"
-            "    -+-2-+-   -2-+-+-             | |    \n"
-            "     | | |     | | |             -+-1-   \n"
-            "Av( -+-+-1- , -+-+-1- ) and Co(   | |   )\n"
-            "     | | |     | | |             -0-+-   \n"
-            "    -0-+-+-   -+-0-+-             | |    \n"
-            "     | | |     | | |                     ")
+            "     | | |                               \n"
+            "    -+-2-+-     | |#              | |    \n"
+            "     | | |     -1-+-             -+-1-   \n"
+            "Av( -+-+-1- ,   |#|   ) and Co(   | |   )\n"
+            "     | | |     -+-0-             -0-+-   \n"
+            "    -0-+-+-    #| |               | |    \n"
+            "     | | |                               ")
 
     def test_flip(self):
         flipped_cell = Cell(frozenset(), frozenset({self.mp_31c2}))
@@ -368,6 +372,15 @@ class UtilsTest(unittest.TestCase):
         padded_lines = Utils.pad_string_to_rectangle(mp_str, 9, 11).split("\n")
         for i, unpadded_line in enumerate(mp_str.split("\n"), start=2):
             assert unpadded_line.center(9) == padded_lines[i]
+
+    def test_mixed_sorting(self):
+        p1 = Perm((0, 2, 1))
+        mp1 = MeshPatt(p1, [(i, i) for i in range(4)])
+
+        p2 = Perm((1, 0))
+        mp2 = MeshPatt(p2, [(2 - i, 2 - i) for i in range(3)])
+
+        assert list(Utils.sorted({p1, mp1, p2, mp2})) == [p2, p1, mp2, mp1]
 
 
 if __name__ == '__main__':

--- a/tests/test_mesh_tiling.py
+++ b/tests/test_mesh_tiling.py
@@ -90,13 +90,13 @@ class CellTest(unittest.TestCase):
             "    -+-0-+-  \n"
             "     | |#|   ")
         assert str(self.mixed_av_co_cell) == (
-            "     | | |                               \n"
-            "    -+-2-+-     | |#              | |    \n"
-            "     | | |     -1-+-             -+-1-   \n"
-            "Av( -+-+-1- ,   |#|   ) and Co(   | |   )\n"
-            "     | | |     -+-0-             -0-+-   \n"
-            "    -0-+-+-    #| |               | |    \n"
-            "     | | |                               ")
+            "     | | |                           \n"
+            "    -+-2-+-    | |#            | |   \n"
+            "     | | |    -1-+-           -+-1-  \n"
+            "Av( -+-+-1- ,  |#|  ) and Co(  | |  )\n"
+            "     | | |    -+-0-           -0-+-  \n"
+            "    -0-+-+-   #| |             | |   \n"
+            "     | | |                           ")
 
     def test_flip(self):
         flipped_cell = Cell(frozenset(), frozenset({self.mp_31c2}))


### PR DESCRIPTION
Updating dependency on `permuta` library to support avoiding a mix of Perms and MeshPatts. Also adding a new method that sorts a mix of Perms and MeshPatts for consistent output in `Cell` and `MeshTiling` visualisation.