### PR TITLE
Cover for Av(empty_set) of words

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ python:
 
 install:
   - pip install --upgrade pip
-  - pip install coveralls==1.8.2
+  - pip install coveralls==1.9.2
 
 script:
   - ./setup.py test

--- a/demo/mesh_tiling.py
+++ b/demo/mesh_tiling.py
@@ -2,15 +2,14 @@ import logging
 from collections import deque, namedtuple
 from itertools import chain, combinations, product
 
+from combcov import CombCov, Rule
 from permuta import Av, MeshPatt, Perm, PermSet
 from permuta.misc import flatten, ordered_set_partitions
-
-from combcov import CombCov, Rule
 
 logger = logging.getLogger("MeshTiling")
 
 
-class MockAvCoPatts():
+class MockAvCoPatts:
     def __init__(self, av_patts, co_patts):
         self.base_perm_set = Av(av_patts)
 
@@ -423,7 +422,7 @@ class MeshTiling(Rule):
                top_bottom_lines
 
 
-class Utils():
+class Utils:
 
     # See https://github.com/PermutaTriangle/CombCov/issues/28
     equivalent_shadings = {

--- a/demo/word_set.py
+++ b/demo/word_set.py
@@ -12,7 +12,7 @@ class WordSet(Rule):
         self.alphabet = tuple(alphabet)
         self.avoid = self._basis_of(avoid)
         self.prefix = prefix
-        self.max_prefix_size = max(0, max(len(av) for av in self.avoid))
+        self.max_prefix_size = max((len(av) for av in self.avoid), default=1)
 
     def contains(self, word):
         return all(av not in word for av in self.avoid)

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 test=pytest
 
 [tool:pytest]
-addopts = --pep8 --cov=combcov --cov-report=term-missing
+addopts = --pep8 --isort --cov=combcov --cov-report=term-missing
 testpaths = demo combcov tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 test=pytest
 
 [tool:pytest]
-addopts = --pep8 --isort --cov=combcov --cov-report=term-missing
+addopts = --pep8 --cov=combcov --cov-report=term-missing
 testpaths = demo combcov tests

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name="CombCov",
-    version="0.6.3",
+    version="0.6.4",
     author="Permuta Triangle",
     author_email="permutatriangle@gmail.com",
     description="Searching for combinatorial covers.",

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,10 @@ setup(
         "permuta==1.2.1",
         "PuLP==1.6.10",
     ],
-    setup_requires=["pytest-runner==5.1"],
+    setup_requires=["pytest-runner==5.2"],
     tests_require=[
-        "pytest==5.1.2",
-        "pytest-cov==2.7.1",
+        "pytest==5.3.2",
+        "pytest-cov==2.8.1",
         "pytest-pep8==1.0.6",
         "pytest-isort==0.3.1",
     ],

--- a/tests/test_mesh_tiling.py
+++ b/tests/test_mesh_tiling.py
@@ -2,11 +2,10 @@ import unittest
 from itertools import combinations, product
 from math import factorial
 
-from permuta import Av, MeshPatt, Perm, PermSet
-
 import pytest
 from combcov import Rule
 from demo.mesh_tiling import Cell, MeshTiling, MockAvCoPatts, Utils
+from permuta import Av, MeshPatt, Perm, PermSet
 
 
 class MockContainingPattsTest(unittest.TestCase):

--- a/tests/test_word_set.py
+++ b/tests/test_word_set.py
@@ -76,6 +76,11 @@ class WordSetTest(unittest.TestCase):
         self.assertNotEqual(word_set, "nonsense")
         self.assertNotEqual(word_set, None)
 
+    def test_avoiding_empty_set(self):
+        word_set = WordSet(self.alphabet, frozenset())
+        subrules = list(word_set.get_subrules())
+        self.assertTrue(len(subrules) > 1)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
It was pointed by Bjarki when reading the thesis that `CombCov` didn't find a cover for Av(empty_set) of words but should easily do so. It turned out that choosing prefixes up to length _at least_ 1 (and then capping at the max length of words in the avoiding set) would allow the framework to generate the necessary rules.