### PR TITLE
Python 3.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
-  - "3.7-dev"
-#  - "3.8-dev"
-#  - "nightly"
+  - "3.8"
+  - "3.8-dev"
+  - "nightly"
   - "pypy3.5"
 
 install:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name="CombCov",
-    version="0.6.4",
+    version="0.6.5",
     author="Permuta Triangle",
     author_email="permutatriangle@gmail.com",
     description="Searching for combinatorial covers.",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     long_description_content_type="text/markdown",
     install_requires=[
         "permuta==1.2.1",
-        "PuLP==1.6.10",
+        "PuLP==2.0",
     ],
     setup_requires=["pytest-runner==5.2"],
     tests_require=[
@@ -46,6 +46,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
 

--- a/tests/test_mesh_tiling.py
+++ b/tests/test_mesh_tiling.py
@@ -73,8 +73,10 @@ class CellTest(unittest.TestCase):
         assert repr(self.mp_cell) == "Av({})".format(repr(self.mp_31c2))
         assert repr(self.mp_cell.flip()) == "Co({})".format(repr(self.mp_31c2))
         assert repr(self.mixed_av_co_cell) == "Av({}) and Co({})".format(
-            ", ".join(repr(p) for p in self.mixed_av_co_cell.obstructions),
-            ", ".join(repr(p) for p in self.mixed_av_co_cell.requirements)
+            ", ".join(repr(p) for p in Utils.sorted(
+                self.mixed_av_co_cell.obstructions)),
+            ", ".join(repr(p) for p in Utils.sorted(
+                self.mixed_av_co_cell.requirements))
         )
 
     def test_str(self):


### PR DESCRIPTION
Newly released version 2.0 of `PuLP` library finally supports Python 3.8. Updating dependency and adding support for 3.8 in `CombCov`.